### PR TITLE
Fix CI failures: Invalid test phone numbers and missing health endpoint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,143 @@
+name: ci
+
+on: push
+
+jobs:
+  # Separate Go tests job (runs once, not 3 times)
+  test-go:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.24.0
+      - name: Run Go unit tests
+        run: go test ./...
+        env:
+          # Suppress email service warnings in tests
+          GMAIL_CLIENT_ID: test
+          GMAIL_CLIENT_SECRET: test
+          GMAIL_REFRESH_TOKEN: test
+          GMAIL_FROM_EMAIL: test@example.com
+
+  test-chromium-desktop:
+    runs-on: ubuntu-latest
+    needs: test-go  # Only run if Go tests pass
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.24.0
+      - name: Node.js Setup
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install build dependencies
+        run: sudo apt-get install -y build-essential python3
+      - name: Install dependencies
+        run: npm ci
+        working-directory: e2e-tests
+      - name: Install browser
+        run: npx playwright install chromium --with-deps
+        working-directory: e2e-tests
+      - name: Start Go-server
+        run: |
+          go build -o gassigeher ./cmd/server
+          DATABASE_PATH=./e2e-tests/test.db JWT_SECRET=test SUPER_ADMIN_EMAIL=admin@tierheim-goeppingen.de PORT=8080 SKIP_SEED=true GMAIL_CLIENT_ID=test GMAIL_CLIENT_SECRET=test GMAIL_REFRESH_TOKEN=test GMAIL_FROM_EMAIL=test@example.com ./gassigeher &
+      - name: Wait for server
+        run: |
+          for i in {1..30}; do
+            curl -s http://localhost:8080/api/version && break
+            sleep 2
+          done
+          curl -sf http://localhost:8080/api/version
+      - name: Run playwright
+        run: npm test -- --project=chromium-desktop
+        working-directory: e2e-tests
+      - name: Stop server
+        if: always()
+        run: pkill -f gassigeher || true
+
+  test-mobile-iphone:
+    runs-on: ubuntu-latest
+    needs: test-go  # Only run if Go tests pass
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.24.0
+      - name: Node.js Setup
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install build dependencies
+        run: sudo apt-get install -y build-essential python3
+      - name: Install dependencies
+        run: npm ci
+        working-directory: e2e-tests
+      - name: Install browser
+        run: npx playwright install webkit --with-deps
+        working-directory: e2e-tests
+      - name: Start Go-server
+        run: |
+          go build -o gassigeher ./cmd/server
+          DATABASE_PATH=./e2e-tests/test.db JWT_SECRET=test SUPER_ADMIN_EMAIL=admin@tierheim-goeppingen.de PORT=8080 SKIP_SEED=true GMAIL_CLIENT_ID=test GMAIL_CLIENT_SECRET=test GMAIL_REFRESH_TOKEN=test GMAIL_FROM_EMAIL=test@example.com ./gassigeher &
+      - name: Wait for server
+        run: |
+          for i in {1..30}; do
+            curl -s http://localhost:8080/api/version && break
+            sleep 2
+          done
+          curl -sf http://localhost:8080/api/version
+      - name: Run playwright
+        run: npm test -- --project=mobile-iphone
+        working-directory: e2e-tests
+      - name: Stop server
+        if: always()
+        run: pkill -f gassigeher || true
+
+  test-mobile-android:
+    runs-on: ubuntu-latest
+    needs: test-go  # Only run if Go tests pass
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.24.0
+      - name: Node.js Setup
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install build dependencies
+        run: sudo apt-get install -y build-essential python3
+      - name: Install dependencies
+        run: npm ci
+        working-directory: e2e-tests
+      - name: Install browser
+        run: npx playwright install chromium --with-deps
+        working-directory: e2e-tests
+      - name: Start Go-server
+        run: |
+          go build -o gassigeher ./cmd/server
+          DATABASE_PATH=./e2e-tests/test.db JWT_SECRET=test SUPER_ADMIN_EMAIL=admin@tierheim-goeppingen.de PORT=8080 SKIP_SEED=true GMAIL_CLIENT_ID=test GMAIL_CLIENT_SECRET=test GMAIL_REFRESH_TOKEN=test GMAIL_FROM_EMAIL=test@example.com ./gassigeher &
+      - name: Wait for server
+        run: |
+          for i in {1..30}; do
+            curl -s http://localhost:8080/api/version && break
+            sleep 2
+          done
+          curl -sf http://localhost:8080/api/version
+      - name: Run playwright
+        run: npm test -- --project=mobile-android
+        working-directory: e2e-tests
+      - name: Stop server
+        if: always()
+        run: pkill -f gassigeher || true

--- a/internal/handlers/auth_handler_test.go
+++ b/internal/handlers/auth_handler_test.go
@@ -66,7 +66,7 @@ func TestAuthHandler_Register(t *testing.T) {
 				name: "missing name",
 				reqBody: map[string]interface{}{
 					"email":            "test@example.com",
-					"phone":            "+49 123",
+					"phone":            "+49 1234567890",
 					"password":         "Test1234",
 					"confirm_password": "Test1234",
 					"accept_terms":     true,
@@ -77,7 +77,7 @@ func TestAuthHandler_Register(t *testing.T) {
 				name: "missing email",
 				reqBody: map[string]interface{}{
 					"name":             "Test",
-					"phone":            "+49 123",
+					"phone":            "+49 1234567890",
 					"password":         "Test1234",
 					"confirm_password": "Test1234",
 					"accept_terms":     true,
@@ -121,7 +121,7 @@ func TestAuthHandler_Register(t *testing.T) {
 		reqBody := map[string]interface{}{
 			"name":             "Test",
 			"email":            "test@example.com",
-			"phone":            "+49 123",
+			"phone":            "+49 1234567890",
 			"password":         "Test1234",
 			"confirm_password": "Different1234",
 			"accept_terms":     true,
@@ -147,7 +147,7 @@ func TestAuthHandler_Register(t *testing.T) {
 		reqBody := map[string]interface{}{
 			"name":             "Test",
 			"email":            "test@example.com",
-			"phone":            "+49 123",
+			"phone":            "+49 1234567890",
 			"password":         "Test1234",
 			"confirm_password": "Test1234",
 			"accept_terms":     false,
@@ -169,7 +169,7 @@ func TestAuthHandler_Register(t *testing.T) {
 		reqBody := map[string]interface{}{
 			"name":             "Test",
 			"email":            "test@example.com",
-			"phone":            "+49 123",
+			"phone":            "+49 1234567890",
 			"password":         "weak",
 			"confirm_password": "weak",
 			"accept_terms":     true,
@@ -194,7 +194,7 @@ func TestAuthHandler_Register(t *testing.T) {
 		reqBody := map[string]interface{}{
 			"name":             "New User",
 			"email":            "existing@example.com",
-			"phone":            "+49 123",
+			"phone":            "+49 1234567890",
 			"password":         "Test1234",
 			"confirm_password": "Test1234",
 			"accept_terms":     true,


### PR DESCRIPTION
## Summary

This PR fixes two critical CI/CD issues preventing the automated test suite from running:

1. **Invalid test phone numbers** - Auth handler tests used "+49 123" (5 digits) which fails phone validation requiring minimum 7 digits
2. **Missing health check endpoint** - CI workflow tried to reach non-existent `/api/health` endpoint instead of correct `/api/version`

## Changes Made

### Test Data Fixes
- Updated 6 test cases in `internal/handlers/auth_handler_test.go`
- Changed phone from "+49 123" to "+49 1234567890" (valid 10-digit number)
- All handler tests now pass successfully

### CI Workflow Improvements
- Created `.github/workflows/ci.yml` with proper configuration
- Fixed health check to use `/api/version` endpoint (which exists in the codebase)
- Added dummy Gmail environment variables to suppress email service initialization warnings in CI
- Optimized test execution: Separate Go unit test job that runs once (not 3x)
- E2E browser tests (Chromium, iPhone, Android) now depend on Go tests passing first
- Added proper server cleanup steps to prevent resource leaks

## Root Cause Analysis

### Phone Validation Issue
The phone validation regex in the user model requires a minimum of 7 digits. Test data had only 5 digits:
- Before: "+49 123" → FAILS (only 5 digits)
- After: "+49 1234567890" → PASSES (10 digits)

### Health Check Issue
The codebase implements `/api/version` endpoint in the server, but CI was checking `/api/health`:
- Before: `curl http://localhost:8080/api/health` → 404 Not Found
- After: `curl http://localhost:8080/api/version` → 200 OK

## Test Plan

- [x] Run Go unit tests locally: `go test ./...` (all tests pass)
- [x] Verify phone validation passes with updated numbers
- [x] Confirm auth handler tests execute without errors
- [x] Check CI workflow syntax is valid YAML
- [x] Verify health check endpoint exists in codebase (`cmd/server/main.go`)
- [x] Confirm Gmail env vars suppress warnings

## Impact

- CI/CD pipeline will now execute successfully
- All 6 auth handler tests will pass (currently failing)
- E2E browser tests will run only after Go tests pass (better resource usage)
- Email service initialization warnings will be suppressed in CI environments

## Related Documentation

See `CLAUDE.md` for:
- Auth handler patterns
- Phone validation requirements (minimum 7 digits)
- CI/CD configuration guidelines

🤖 Generated with [Claude Code](https://claude.com/claude-code)